### PR TITLE
[JENKINS-33105] preserve blank/empty lines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.509.4</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.554.1</version>
   </parent>
 
   <artifactId>linenumbers</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/linenumbers/LineNumbersAnnotator.java
+++ b/src/main/java/org/jenkinsci/plugins/linenumbers/LineNumbersAnnotator.java
@@ -59,10 +59,17 @@ public class LineNumbersAnnotator extends ConsoleAnnotator<Object> {
       calls++;
       int end = text.length() - 1;
 
-      // Trick to make sure we wrap everything including the Timestamp from Timestamper plugin
-      text.addMarkup(0, 0, "",
-          MessageFormat.format("<p class=\"line\"><a class=\"linenumber\" id=\"L{0}\" href=\"#L{0}\"></a><span>", calls));
-      text.addMarkup(end, end, "", "</span></p>");
+      if (text.getText().matches("^\\s$")) {
+        // Trick to make sure we wrap everything including the Timestamp from Timestamper plugin
+        text.addMarkup(0, 0, "",
+            MessageFormat.format("<p class=\"empty\"><a class=\"linenumber\" id=\"L{0}\" href=\"#L{0}\"></a><span>", calls));
+        text.addMarkup(end, end, "", "</span></p>");
+        System.out.println("Hit");
+      } else {
+        text.addMarkup(0, 0, "",
+            MessageFormat.format("<p class=\"line\"><a class=\"linenumber\" id=\"L{0}\" href=\"#L{0}\"></a><span>", calls));
+        text.addMarkup(end, end, "", "</span></p>");
+      }
     }
     return this;
   }

--- a/src/main/java/org/jenkinsci/plugins/linenumbers/LineNumbersAnnotator.java
+++ b/src/main/java/org/jenkinsci/plugins/linenumbers/LineNumbersAnnotator.java
@@ -64,7 +64,6 @@ public class LineNumbersAnnotator extends ConsoleAnnotator<Object> {
         text.addMarkup(0, 0, "",
             MessageFormat.format("<p class=\"empty\"><a class=\"linenumber\" id=\"L{0}\" href=\"#L{0}\"></a><span>", calls));
         text.addMarkup(end, end, "", "</span></p>");
-        System.out.println("Hit");
       } else {
         text.addMarkup(0, 0, "",
             MessageFormat.format("<p class=\"line\"><a class=\"linenumber\" id=\"L{0}\" href=\"#L{0}\"></a><span>", calls));

--- a/src/main/resources/org/jenkinsci/plugins/linenumbers/LineNumbersAnnotatorFactory/style.css
+++ b/src/main/resources/org/jenkinsci/plugins/linenumbers/LineNumbersAnnotatorFactory/style.css
@@ -42,6 +42,12 @@ p.line {
 	font-family:monospace;
 }
 
+p.empty {
+	display:block;
+	white-space:nowrap;
+	font-family:monospace;
+}
+
 pre p,pre span {
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
- [x] Automated tests (see https://github.com/jenkinsci/acceptance-test-harness/pull/350)

Hi, 
my first commit didnt really fix this problem in all situations. This one I tested with following script before/after:

```
echo ""
echo " "
echo "  "
echo """
"""
```

**BEFORE:** 
![screenshot from 2017-07-26 01-13-48](https://user-images.githubusercontent.com/17890112/28597710-bd21a19e-719f-11e7-826b-15fa464a4093.png)

**AFTER:**
![screenshot from 2017-07-26 01-11-41](https://user-images.githubusercontent.com/17890112/28597674-8eaaa00e-719f-11e7-8dea-e3749f524d69.png)

I dont know right now how to test this, if you have an idea I would try to implement the test.
Greetings, Ben
