### PR TITLE
[JENKINS-41284] Adding scroll down to show the target line.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.509.4</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.554.1</version>
   </parent>
 
   <artifactId>linenumbers</artifactId>

--- a/src/main/resources/org/jenkinsci/plugins/linenumbers/LineNumbersAnnotatorFactory/script.js
+++ b/src/main/resources/org/jenkinsci/plugins/linenumbers/LineNumbersAnnotatorFactory/script.js
@@ -1,5 +1,32 @@
-Behaviour.specify('div.fold', 'fold.toggle', 10, function(element) {
-	element.onclick = function() {
-		element.toggleClassName('open');
-	}
-});
+/*global window */
+(function () {
+    "use strict";
+
+    Behaviour.specify('div.fold', 'fold.toggle', 10, function (element) {
+        element.onclick = function () {
+            element.toggleClassName('open');
+        };
+    });
+
+    function scrollToElement(element) {
+        window.scrollTo(0, element.offsetTop - 30);
+    }
+
+    $(document).on("click", "a[href^='#L']", function (event) {
+        event.preventDefault();
+        scrollToElement(event.target);
+    });
+
+    $(document).observe("dom:loaded", function () {
+        var hash = window.location.hash.substring(1),
+            targetLine;
+        if (hash.length !== 0) {
+            targetLine = document.getElementById(hash);
+            if (targetLine) {
+                window.setTimeout(function () {
+                    scrollToElement(targetLine);
+                }, 200);
+            }
+        }
+    });
+}());


### PR DESCRIPTION
The `breadcrumBar` covers the target line of the links.

- [x] Automated tests (see https://github.com/jenkinsci/acceptance-test-harness/pull/346)


**BEFORE**
![screenshot from 2017-07-26 02-57-47](https://user-images.githubusercontent.com/17890112/28599859-4175e550-71ae-11e7-9b4a-3a0704858727.png)

**AFTER**
![screenshot from 2017-07-26 02-57-32](https://user-images.githubusercontent.com/17890112/28599861-4736024a-71ae-11e7-8b49-8af776685538.png)
